### PR TITLE
Add decision tree and random forest implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,8 @@ Goals -
         - Transformers
         - Bert Ernie GPT 2
         - LLM
+
+## Decision Trees and Random Forest
+
+Implemented a simple `DecisionTreeClassifier` and `RandomForestClassifier` from scratch in the `algos` package.
+Run `python demo_decision_forest.py` to see a demo on the Iris dataset (requires scikit-learn for the dataset and metrics).

--- a/algos/__init__.py
+++ b/algos/__init__.py
@@ -1,0 +1,4 @@
+from .decision_tree import DecisionTreeClassifier
+from .random_forest import RandomForestClassifier
+
+__all__ = ["DecisionTreeClassifier", "RandomForestClassifier"]

--- a/algos/decision_tree.py
+++ b/algos/decision_tree.py
@@ -1,0 +1,80 @@
+import numpy as np
+from collections import Counter
+
+class DecisionTreeClassifier:
+    class Node:
+        def __init__(self, feature_index=None, threshold=None, left=None, right=None, *, value=None):
+            self.feature_index = feature_index
+            self.threshold = threshold
+            self.left = left
+            self.right = right
+            self.value = value
+
+    def __init__(self, max_depth=None, min_samples_split=2, n_features=None):
+        self.max_depth = max_depth
+        self.min_samples_split = min_samples_split
+        self.n_features = n_features  # number of features to consider at each split
+        self.root = None
+
+    def fit(self, X, y):
+        X = np.array(X)
+        y = np.array(y)
+        n_samples, n_features = X.shape
+        self.n_features = n_features if self.n_features is None else min(self.n_features, n_features)
+        self.root = self._grow_tree(X, y)
+
+    def predict(self, X):
+        X = np.array(X)
+        return np.array([self._traverse_tree(x, self.root) for x in X])
+
+    def _gini(self, y):
+        counts = np.bincount(y)
+        probabilities = counts / len(y)
+        return 1 - np.sum(probabilities ** 2)
+
+    def _best_split(self, X, y):
+        n_samples, n_features = X.shape
+        if n_samples < self.min_samples_split:
+            return None, None
+        feature_indices = np.random.choice(n_features, self.n_features, replace=False)
+        best_gini = 1.0
+        best_idx, best_thresh = None, None
+        for idx in feature_indices:
+            thresholds = np.unique(X[:, idx])
+            for threshold in thresholds:
+                left_indices = X[:, idx] <= threshold
+                right_indices = X[:, idx] > threshold
+                if np.sum(left_indices) == 0 or np.sum(right_indices) == 0:
+                    continue
+                gini_left = self._gini(y[left_indices])
+                gini_right = self._gini(y[right_indices])
+                gini = (len(y[left_indices]) * gini_left + len(y[right_indices]) * gini_right) / n_samples
+                if gini < best_gini:
+                    best_gini = gini
+                    best_idx = idx
+                    best_thresh = threshold
+        return best_idx, best_thresh
+
+    def _grow_tree(self, X, y, depth=0):
+        num_samples_per_class = [np.sum(y == i) for i in np.unique(y)]
+        predicted_class = np.argmax(num_samples_per_class)
+        node = self.Node(value=predicted_class)
+
+        if depth < (self.max_depth if self.max_depth is not None else np.inf):
+            idx, threshold = self._best_split(X, y)
+            if idx is not None:
+                indices_left = X[:, idx] <= threshold
+                X_left, y_left = X[indices_left], y[indices_left]
+                X_right, y_right = X[~indices_left], y[~indices_left]
+                if len(y_left) > 0 and len(y_right) > 0:
+                    node = self.Node(feature_index=idx, threshold=threshold)
+                    node.left = self._grow_tree(X_left, y_left, depth + 1)
+                    node.right = self._grow_tree(X_right, y_right, depth + 1)
+        return node
+
+    def _traverse_tree(self, x, node):
+        if node.value is not None and node.feature_index is None:
+            return node.value
+        if x[node.feature_index] <= node.threshold:
+            return self._traverse_tree(x, node.left)
+        return self._traverse_tree(x, node.right)

--- a/algos/random_forest.py
+++ b/algos/random_forest.py
@@ -1,0 +1,45 @@
+import numpy as np
+from collections import Counter
+from .decision_tree import DecisionTreeClassifier
+
+class RandomForestClassifier:
+    def __init__(self, n_estimators=10, max_depth=None, min_samples_split=2, max_features='sqrt'):
+        self.n_estimators = n_estimators
+        self.max_depth = max_depth
+        self.min_samples_split = min_samples_split
+        self.max_features = max_features
+        self.trees = []
+
+    def _get_n_features(self, n_features):
+        if isinstance(self.max_features, int):
+            return self.max_features
+        if self.max_features == 'sqrt':
+            return max(1, int(np.sqrt(n_features)))
+        if self.max_features == 'log2':
+            return max(1, int(np.log2(n_features)))
+        return n_features
+
+    def fit(self, X, y):
+        X = np.array(X)
+        y = np.array(y)
+        n_samples, n_features = X.shape
+        self.trees = []
+        n_feats = self._get_n_features(n_features)
+        for _ in range(self.n_estimators):
+            indices = np.random.choice(n_samples, n_samples, replace=True)
+            X_sample = X[indices]
+            y_sample = y[indices]
+            tree = DecisionTreeClassifier(
+                max_depth=self.max_depth,
+                min_samples_split=self.min_samples_split,
+                n_features=n_feats,
+            )
+            tree.fit(X_sample, y_sample)
+            self.trees.append(tree)
+
+    def predict(self, X):
+        X = np.array(X)
+        tree_preds = np.array([tree.predict(X) for tree in self.trees])
+        tree_preds = np.swapaxes(tree_preds, 0, 1)
+        y_pred = [Counter(row).most_common(1)[0][0] for row in tree_preds]
+        return np.array(y_pred)

--- a/demo_decision_forest.py
+++ b/demo_decision_forest.py
@@ -1,0 +1,16 @@
+import numpy as np
+from algos import DecisionTreeClassifier, RandomForestClassifier
+from sklearn.datasets import load_iris
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import accuracy_score
+
+X, y = load_iris(return_X_y=True)
+X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.3, random_state=42)
+
+dt = DecisionTreeClassifier(max_depth=5)
+dt.fit(X_train, y_train)
+print('DecisionTree accuracy:', accuracy_score(y_test, dt.predict(X_test)))
+
+rf = RandomForestClassifier(n_estimators=10, max_depth=5)
+rf.fit(X_train, y_train)
+print('RandomForest accuracy:', accuracy_score(y_test, rf.predict(X_test)))


### PR DESCRIPTION
## Summary
- implement a simple Decision Tree classifier
- build a Random Forest classifier using the tree implementation
- add a small demo script using the Iris dataset
- document how to run the demo in the README

## Testing
- `pip install numpy scikit-learn --quiet`
- `python3 demo_decision_forest.py`

------
https://chatgpt.com/codex/tasks/task_e_68411102fe7083309e3aaae26bf21ea3